### PR TITLE
fix: resolve catalog loading issue for categories other than "Alle Fr…

### DIFF
--- a/lib/providers/questions_provider.dart
+++ b/lib/providers/questions_provider.dart
@@ -267,7 +267,23 @@ class QuestionsProvider extends ChangeNotifier {
   }
 
   Future<void> loadCategory(String category) async {
-    await loadQuestionsByCategory(category);
+    // Find the category in the selected course manifest
+    if (_selectedCourseManifest == null) {
+      _error = 'Kein Kurs ausgewählt';
+      notifyListeners();
+      return;
+    }
+
+    final categoryInfo = _selectedCourseManifest!.categories.firstWhere(
+      (c) => c.id == category,
+      orElse: () =>
+          throw Exception('Category $category not found in course manifest'),
+    );
+
+    // Load questions from all catalogs referenced by this category
+    await _loadQuestionsFromDatabase(
+      () => _repository.getQuestionsByCatalogs(categoryInfo.catalogRefs),
+    );
   }
 
   // Filter questions by bookmarks (now loads from database)

--- a/lib/repositories/question_repository.dart
+++ b/lib/repositories/question_repository.dart
@@ -116,6 +116,23 @@ class QuestionRepository {
     return _mapToQuestions(maps);
   }
 
+  Future<List<Question>> getQuestionsByCatalogs(List<String> catalogIds) async {
+    if (catalogIds.isEmpty) {
+      return [];
+    }
+
+    final db = await _databaseHelper.database;
+    final placeholders = catalogIds.map((_) => '?').join(', ');
+    final maps = await db.query(
+      DatabaseHelper.tableQuestions,
+      where: 'category IN ($placeholders)',
+      whereArgs: catalogIds,
+      orderBy: 'number ASC',
+    );
+
+    return _mapToQuestions(maps);
+  }
+
   Future<List<Question>> getQuestionsByCourse(String courseId) async {
     final db = await _databaseHelper.database;
     final maps = await db.query(

--- a/test/repositories/question_repository_test.dart
+++ b/test/repositories/question_repository_test.dart
@@ -113,6 +113,67 @@ void main() {
       expect(result.length, 3);
     });
 
+    test('getQuestionsByCatalogs should filter by multiple catalogs', () async {
+      // Insert questions with different categories (catalogs)
+      final basisfragen = TestDatabaseHelper.generateTestQuestions(
+        count: 3,
+        category: 'basisfragen',
+        idPrefix: 'basis',
+      );
+      final spezifischeSee = TestDatabaseHelper.generateTestQuestions(
+        count: 2,
+        category: 'spezifische-see',
+        idPrefix: 'see',
+      );
+      final spezifischeBinnen = TestDatabaseHelper.generateTestQuestions(
+        count: 2,
+        category: 'spezifische-binnen',
+        idPrefix: 'binnen',
+      );
+
+      await repository.insertQuestions(basisfragen, 'sbf-see');
+      await repository.insertQuestions(spezifischeSee, 'sbf-see');
+      await repository.insertQuestions(spezifischeBinnen, 'sbf-binnen');
+
+      // Query multiple catalogs at once
+      final result = await repository.getQuestionsByCatalogs([
+        'basisfragen',
+        'spezifische-see',
+      ]);
+
+      expect(result.length, 5);
+      expect(
+        result.every(
+          (q) => q.category == 'basisfragen' || q.category == 'spezifische-see',
+        ),
+        true,
+      );
+    });
+
+    test(
+      'getQuestionsByCatalogs should return empty list for empty input',
+      () async {
+        final result = await repository.getQuestionsByCatalogs([]);
+
+        expect(result, isEmpty);
+      },
+    );
+
+    test('getQuestionsByCatalogs should handle single catalog', () async {
+      final basisfragen = TestDatabaseHelper.generateTestQuestions(
+        count: 3,
+        category: 'basisfragen',
+        idPrefix: 'basis',
+      );
+
+      await repository.insertQuestions(basisfragen, 'sbf-see');
+
+      final result = await repository.getQuestionsByCatalogs(['basisfragen']);
+
+      expect(result.length, 3);
+      expect(result.every((q) => q.category == 'basisfragen'), true);
+    });
+
     test('addBookmark and removeBookmark should manage bookmarks', () async {
       await repository.insertQuestions(testQuestions, 'test-course');
       final questionId = testQuestions.first.id;


### PR DESCRIPTION
…agen"

Categories like "Basisfragen" and "Spezifische See" were not loading because of a mismatch between category IDs in the manifest and catalog IDs stored in the database.

Changes:
- Add QuestionRepository.getQuestionsByCatalogs() to query multiple catalogs
- Update QuestionsProvider.loadCategory() to use catalogRefs from manifest
- Add comprehensive tests for the new catalog querying functionality

The fix maps category IDs to their catalog references (e.g., "basics" → ["basisfragen"]) and queries the database using the actual catalog IDs.