### PR TITLE
fix: add notification delegate setup for iOS and macOS

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -7,6 +7,11 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // Set notification delegate for iOS 10+
+    if #available(iOS 10.0, *) {
+      UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
+    }
+
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -3,6 +3,13 @@ import FlutterMacOS
 
 @main
 class AppDelegate: FlutterAppDelegate {
+  override func applicationDidFinishLaunching(_ notification: Notification) {
+    // Set notification delegate for macOS 10.14+
+    if #available(macOS 10.14, *) {
+      UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
+    }
+  }
+
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true
   }


### PR DESCRIPTION
## Summary
- Added required `UNUserNotificationCenter` delegate setup for iOS and macOS
- Fixes notification handling according to `flutter_local_notifications` documentation

## Changes
### iOS (AppDelegate.swift)
- ✅ Added notification delegate in `didFinishLaunchingWithOptions`
- Available for iOS 10.0+

### macOS (AppDelegate.swift)  
- ✅ Added notification delegate in `applicationDidFinishLaunching`
- Available for macOS 10.14+

## Why This Matters
Without these delegates:
- ❌ Foreground notifications may not display properly
- ❌ Notification interactions may not be handled
- ❌ Custom notification actions won't work

With these delegates:
- ✅ Notifications display correctly when app is in foreground
- ✅ Notification taps are properly handled
- ✅ Full notification functionality enabled

## Testing
- ✅ CocoaPods dependencies updated (iOS & macOS)
- ✅ Swift analysis passed with no issues
- ✅ Follows official flutter_local_notifications setup guide

## Documentation Reference
- [iOS Setup](https://pub.dev/packages/flutter_local_notifications#-ios-setup)
- [macOS Setup](https://pub.dev/packages/flutter_local_notifications#-macos-setup)